### PR TITLE
166 unsupported architecture for macos arm64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Removed: For features removed in this release.
 Fixed: For any bug fixes.
 Security: For vulnerabilities.
 
+##  [0.7.2] - 2025-04-28
+### Fixed
+- Wrong reference and inclusion of library for supported architecture (arm64) in Darwin, resulting in python package not working in MacOS
+
 ## [0.7.1] - 2025-04-15
 ### Added
 - Functionality to download PDFs from text lists of URLs

--- a/python/MANIFEST.in
+++ b/python/MANIFEST.in
@@ -3,5 +3,4 @@ include README.md
 include LICENSE
 include prismaid/libprismaid_linux_amd64.so
 include prismaid/libprismaid_windows_amd64.dll
-include prismaid/libprismaid_darwin_amd64.dylib
-
+include prismaid/libprismaid_darwin_arm64.dylib

--- a/python/prismaid/__init__.py
+++ b/python/prismaid/__init__.py
@@ -19,8 +19,8 @@ elif system == "Windows":
         raise OSError(f"Unsupported architecture for Windows: {architecture}")
 
 elif system == "Darwin":
-    if architecture == "amd64" or architecture == "x86_64":
-        lib = CDLL(__file__.replace("__init__.py", "libprismaid_darwin_amd64.dylib"))
+    if architecture == "arm64" or architecture == "ARM64":
+        lib = CDLL(__file__.replace("__init__.py", "libprismaid_darwin_arm64.dylib"))
     else:
         raise OSError(f"Unsupported architecture for macOS: {architecture}")
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -45,9 +45,6 @@ packages = ["prismaid"]
 [tool.hatch.build]
 include = [
     "prismaid/libprismaid_linux_amd64.so",
-    "prismaid/libprismaid_linux_arm64.so",
     "prismaid/libprismaid_windows_amd64.dll",
-    "prismaid/libprismaid_darwin_amd64.dylib",
     "prismaid/libprismaid_darwin_arm64.dylib"
 ]
-


### PR DESCRIPTION
Applied changes to MANIFEST, pyproject.toml, and __init__.py should fix the problem for any arm based MacOS user of the python package.
After merging of pull request, a new release will be deployed through CI-CD and will be available in a matter of hours on Pypi.
Close the issue #166 and report this comment there.