### PR TITLE
Fix macOS runner reference

### DIFF
--- a/.github/workflows/build_shared.yml
+++ b/.github/workflows/build_shared.yml
@@ -297,7 +297,7 @@ jobs:
     build-macos-arm64:
         needs: update-version-for-r
         name: Build macOS Arm64 Shared Library
-        runs-on: macos-latest
+        runs-on: macos-14
         env:
             GH_TOKEN: ${{ secrets.PAT_TOKEN }}
         steps:


### PR DESCRIPTION
## Summary
- pin the GitHub Actions macOS runner to version 14

## Testing
- `go vet ./...`
- `go test ./...` *(fails: TestExtractPDF/Invalid_URL, TestDownloadPDF/Invalid_URL)*

------
https://chatgpt.com/codex/tasks/task_e_6878f614f2b8832c8d560830c03196b4