### PR TITLE
Fix documentation link paths after restructure

### DIFF
--- a/docs/Review/review-workflow.md
+++ b/docs/Review/review-workflow.md
@@ -180,7 +180,7 @@ toml_config = read("project.toml", String)
 PrismAId.run_review(toml_config)
 ```
 
-You can use the [Review Configurator](review-configurator) web tool to easily create TOML configurations or use the `-init` flag with the binary.
+You can use the [Review Configurator](../review/review-configurator) web tool to easily create TOML configurations or use the `-init` flag with the binary.
 
 ## Information Extraction Mechanism
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,18 +49,18 @@ Our tools support a comprehensive systematic review workflow following the stand
 
 ## Table of Contents
 Explore this website for comprehensive guidance on using the prismAId toolkit:
-1. [Installation & Setup](installation-setup): Learn how to install prismAId tools and configure them for different environments.
-2. [Screening Tool](screening-tool): Filter manuscripts with multiple screening filters:
+1. [Installation & Setup](installation/setup-overwiew): Learn how to install prismAId tools and configure them for different environments.
+2. [Screening Tool](tools/screening-tool): Filter manuscripts with multiple screening filters:
    - [Deduplication](filters/deduplication) - Identify and remove duplicate manuscripts
    - [Language Detection](filters/language) - Filter by manuscript language
    - [Article Type](filters/article-type) - Classify publication types
    - [Topic Relevance](filters/topic-relevance) - Score relevance to research topics
-3. [Download Tool](download-tool): Discover how to efficiently acquire papers from Zotero collections or URL lists.
-4. [Convert Tool](convert-tool): Learn to transform documents from various formats into plain text for analysis.
-5. [Review Tool](review-tool): Master the core systematic review functionality for extracting structured information.
-6. [Review Support](review-support): Learn about methodologies and best practices for systematic reviews with prismAId.
-7. [Review Configurator](review-configurator): Quickly set up your review project with the web initializer tool.
-8. [Help & Development](help-development): Find troubleshooting tips and answers to frequently asked questions about prismAId features and results and how you can contribute to its advancement.
+3. [Download Tool](tools/download-tool): Discover how to efficiently acquire papers from Zotero collections or URL lists.
+4. [Convert Tool](tools/convert-tool): Learn to transform documents from various formats into plain text for analysis.
+5. [Review Tool](tools/review-tool): Master the core systematic review functionality for extracting structured information.
+6. [Review Support](Review/review-workflow): Learn about methodologies and best practices for systematic reviews with prismAId.
+7. [Review Configurator](review/review-configurator): Quickly set up your review project with the web initializer tool.
+8. [Help & Development](support/help): Find troubleshooting tips and answers to frequently asked questions about prismAId features and results and how you can contribute to its advancement.
 
 ## New Releases and Updates
 Follow the Matrix [prismAId Announcements Room](https://matrix.to/#/#prismAId-announcements:matrix.org) for the latest updates and release notifications.

--- a/docs/installation/additional-setup.md
+++ b/docs/installation/additional-setup.md
@@ -8,7 +8,7 @@ layout: default
 ## Configuration Initialization
 prismAId offers multiple ways to create review configuration files:
 
-1. **Web Initializer**: Use the browser-based tool on the [Review Configurator](review-configurator) page to create TOML configuration files through a user-friendly interface.
+1. **Web Initializer**: Use the browser-based tool on the [Review Configurator](../review/review-configurator) page to create TOML configuration files through a user-friendly interface.
 
 2. **Template Files**: Ready-to-use configuration templates are available in the [projects/templates](https://github.com/open-and-sustainable/prismaid/tree/main/projects/templates) directory for review, screening, and Zotero download tools.
 

--- a/docs/support/development.md
+++ b/docs/support/development.md
@@ -14,7 +14,7 @@ We welcome contributions to improve any aspect of the prismAId toolkit, whether 
 - **Community Engagement**: Connect with us through GitHub [issues](https://github.com/open-and-sustainable/prismaid/issues) and [discussions](https://github.com/open-and-sustainable/prismaid/discussions) for feature requests, suggestions, or questions. - Discuss in the Matrix [prismAId Support Room](https://matrix.to/#/#prismAId-support:matrix.org) or follow the [prismAId Announcements Room](https://matrix.to/#/#prismAId-announcements:matrix.org) for the latest updates and release notifications.
 
 ### Guidelines
-For detailed contribution guidelines, see our [`CONTRIBUTING.md`](CONTRIBUTING.md) and [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).
+For detailed contribution guidelines, see our [`CONTRIBUTING.md`](../CONTRIBUTING.md) and [`CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md).
 
 ## Software Stack
 

--- a/docs/tools/review-tool.md
+++ b/docs/tools/review-tool.md
@@ -85,7 +85,7 @@ PrismAId.run_review(toml_config)
 
 ## Configuration File Structure
 
-The Review tool is driven by a TOML configuration file that defines all aspects of your systematic review. You can create this file manually, use the `-init` flag with the binary for an interactive setup, or use the [Review Configurator](review-configurator) web tool.
+The Review tool is driven by a TOML configuration file that defines all aspects of your systematic review. You can create this file manually, use the `-init` flag with the binary for an interactive setup, or use the [Review Configurator](../review/review-configurator) web tool.
 
 The configuration file consists of three main sections:
 
@@ -426,7 +426,7 @@ The Review tool is the culmination of the systematic review workflow:
    - Convert downloaded papers to text format for analysis
 
 5. **Review Configuration**:
-   - Set up your review project configuration using the [Review Configurator](review-configurator) or the `-init` flag
+   - Set up your review project configuration using the [Review Configurator](../review/review-configurator) or the `-init` flag
    - Define your information extraction protocol through prompt and review sections
 
 6. **Systematic Review** (Review Tool):

--- a/docs/tools/screening-tool.md
+++ b/docs/tools/screening-tool.md
@@ -172,28 +172,28 @@ rpm_limit = 0                             # Requests per minute limit
 
 The screening tool includes four main filters that can be applied in sequence:
 
-1. **[Deduplication Filter](filters/deduplication.md)** - Identifies and removes duplicate manuscripts
-2. **[Language Detection Filter](filters/language.md)** - Filters manuscripts by language
-3. **[Article Type Classification Filter](filters/article-type.md)** - Classifies and filters by publication type
-4. **[Topic Relevance Filter](filters/topic-relevance.md)** - Scores manuscripts based on topic relevance
+1. **[Deduplication Filter](../filters/deduplication.md)** - Identifies and removes duplicate manuscripts
+2. **[Language Detection Filter](../filters/language.md)** - Filters manuscripts by language
+3. **[Article Type Classification Filter](../filters/article-type.md)** - Classifies and filters by publication type
+4. **[Topic Relevance Filter](../filters/topic-relevance.md)** - Scores manuscripts based on topic relevance
 
 Each filter has detailed documentation available through the links above. Below is a brief overview of each filter's capabilities.
 
 ### Deduplication Filter
 
-Identifies duplicate manuscripts using intelligent field comparison or AI-assisted semantic matching. See [full documentation](filters/deduplication.md).
+Identifies duplicate manuscripts using intelligent field comparison or AI-assisted semantic matching. See [full documentation](../filters/deduplication.md).
 
 ### Language Detection Filter
 
-Identifies manuscript language and filters based on accepted languages using rule-based pattern matching or AI-assisted semantic detection. See [full documentation](filters/language.md).
+Identifies manuscript language and filters based on accepted languages using rule-based pattern matching or AI-assisted semantic detection. See [full documentation](../filters/language.md).
 
 ### Article Type Classification Filter
 
-Classifies manuscripts into multiple overlapping categories (traditional types, methodological types, and study scope). A single manuscript can belong to several types simultaneously. See [full documentation](filters/article-type.md).
+Classifies manuscripts into multiple overlapping categories (traditional types, methodological types, and study scope). A single manuscript can belong to several types simultaneously. See [full documentation](../filters/article-type.md).
 
 ### Topic Relevance Filter
 
-Scores manuscripts based on their relevance to user-specified research topics using keyword matching, concept matching, and field relevance analysis. See [full documentation](filters/topic-relevance.md).
+Scores manuscripts based on their relevance to user-specified research topics using keyword matching, concept matching, and field relevance analysis. See [full documentation](../filters/topic-relevance.md).
 
 ## Filter Interaction and Processing Order
 
@@ -713,7 +713,7 @@ log_level = "high"  # Saves detailed log file
 
 ---
 
-For more information on systematic review workflows, see the [Review Support](review-support) documentation.
+For more information on systematic review workflows, see the [Review Support](../Review/review-workflow) documentation.
 
 
 <div id="wcb" class="carbonbadge"></div>


### PR DESCRIPTION
## Summary
- update table of contents entries in docs index to point to current pages
- fix review configurator and review workflow links referenced across tooling docs
- correct support and installation page links to shared contributing resources

## Testing
- not run (documentation changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6921c9cd850c8322958103812e8c4e3b)